### PR TITLE
Allow customizing allowedHostPaths in forwarder PSP

### DIFF
--- a/bitnami/fluentd/templates/forwarder-psp.yaml
+++ b/bitnami/fluentd/templates/forwarder-psp.yaml
@@ -11,9 +11,7 @@ spec:
   requiredDropCapabilities:
     - ALL
   allowedHostPaths:
-    - pathPrefix: '/var/lib/docker/containers'
-      readOnly: true
-    - pathPrefix: '/var/log'
+    {{- toYaml .Values.forwarder.podSecurityPolicy.allowedHostPaths | nindent 4 }}
   volumes:
     - 'configMap'
     - 'emptyDir'

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -407,6 +407,12 @@ forwarder:
     create: true
     pspEnabled: false
 
+  podSecurityPolicy:
+    allowedHostPaths:
+      - pathPrefix: '/var/lib/docker/containers'
+        readOnly: true
+      - pathPrefix: '/var/log'
+
   ## Add init containers to forwarder pods
   ## For example:
   ## initContainers:


### PR DESCRIPTION
Modifies the forwarder-psp.yaml so users can customize the allowedHostPaths setting. This change isn't ready to contribute back to upstream because it doesn't establish any good standards / creates a whole new "podSecurityPolicy" context that doesn't fit their existing pattern. At the very least, we'd want to move `rbac.pspEnabled` to `podSecurityPolicy.create` and update references to that.

For ezCater, we'll be using this to support mounting the socket path at `/var/run/td-agent`.

There is a small diff between this and the original setup: the quotes around the pathPrefix are lost when toYaml strips them out. Since toYaml is doing this, I assume this is valid yaml.

Original:
```pathPrefix: '/var/lib/docker/containers'```
New:
```pathPrefix: /var/lib/docker/containers```