### PR TITLE
Revert forwarder ClusterRole PSP resourceNames to match our PSP

### DIFF
--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -28,7 +28,7 @@ rules:
     resources:
       - "podsecuritypolicies"
     resourceNames:
-      - {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "forwarder" }}
+      - {{ include "common.names.fullname" . }}-forwarder
     verbs:
       - "use"
   {{- end }}


### PR DESCRIPTION
See title.

This was done manually in production already.

Note, that I'm not bumping versions here. ~~I'll dependency update and re-upload from here: https://github.com/ezcater/helm-charts/tree/main/charts/fluentd-forwarder, then check Argo diff.~~ Already did it. The diff matches what's live: https://argocd.ezcater.net/applications/fluentd-forwarder-production1?resource=